### PR TITLE
Tiny type tweaks

### DIFF
--- a/packages/core/src/derived.ts
+++ b/packages/core/src/derived.ts
@@ -19,6 +19,8 @@ import { validate } from './utils.js';
 
 // Derived
 export class Derived<T> {
+  readonly type = 'derived';
+
   computeFn: () => T;
   lastValue?: T;
   status: STATUS = DIRTY;

--- a/packages/core/src/reaction.ts
+++ b/packages/core/src/reaction.ts
@@ -14,6 +14,8 @@ import {
 import { validate } from './utils.js';
 
 export class Reaction {
+  readonly type = 'reaction';
+
   sources: Set<Signal<unknown> | Derived<unknown>> | null = null;
   observers = null;
   fn: () => void;
@@ -98,6 +100,6 @@ export class Reaction {
   }
 }
 
-export function isReaction(v: unknown): v is Reaction {
-  return v instanceof Reaction;
+export function isReaction(v: Derived<unknown> | Reaction): v is Reaction {
+  return v.type === 'reaction';
 }

--- a/packages/core/src/signal.ts
+++ b/packages/core/src/signal.ts
@@ -51,18 +51,15 @@ export class _Signal<T> {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Signal<T> extends Omit<_Signal<T>, '_isEqual'> {}
 
-export function createSignal(): Signal<unknown>;
-export function createSignal<T>(value: T, isEqual?: Equality<T> | false): Signal<T>;
+export function createSignal(value?: null | undefined): Signal<unknown>;
+export function createSignal<T extends {}>(value: T, isEqual?: Equality<T> | false): Signal<T>;
 export function createSignal<T extends {}>(
-  value?: T,
+  value?: T | null | undefined,
   isEqual?: Equality<T> | false
 ): Signal<T> | Signal<unknown> {
-  if (arguments.length === 0) {
-    return new _Signal(null as unknown, neverEqual);
+  if (arguments.length === 0 || value == null) {
+    return new _Signal(null, neverEqual);
   } else {
-    // SAFETY: TS doesn't understand that the `arguments` check means there is
-    // always *something* passed as `value` here, and therefore that it is safe
-    // to treat `value` as indicating what `T` must be.
-    return new _Signal(value as T, isEqual);
+    return new _Signal(value, isEqual);
   }
 }

--- a/packages/react/src/useSignal.ts
+++ b/packages/react/src/useSignal.ts
@@ -1,7 +1,9 @@
-import { createSignal } from '@signalis/core';
+import { createSignal, type Signal } from '@signalis/core';
 import { useMemo } from 'react';
 import { EMPTY } from './empty.js';
 
-export function useSignal<T>(value: T) {
-  return useMemo(() => createSignal(value), EMPTY);
+export function useSignal(value?: null | undefined): Signal<unknown>;
+export function useSignal<T extends {}>(value: T): Signal<T>;
+export function useSignal<T extends {}>(value?: T | null | undefined): Signal<T> | Signal<unknown> {
+  return useMemo(() => (value ? createSignal(value) : createSignal(null)), EMPTY);
 }


### PR DESCRIPTION
- Use a tag (not that kind!) instead of `instanceof` for Reaction/Derived
- Eliminate the need for casts in `createSignal()`