### PR TITLE
react perf

### DIFF
--- a/packages/core/src/reaction.ts
+++ b/packages/core/src/reaction.ts
@@ -120,6 +120,7 @@ export class Reaction {
   }
 
   dispose() {
+    unlinkObservers(this);
     this.isDisposed = true;
     if (this.cleanupFn) {
       this.cleanupFn();

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,10 +28,9 @@
   "keywords": [],
   "author": "Chris Freeman",
   "license": "MIT",
-  "dependencies": {
-    "@signalis/core": "workspace:*"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "@signalis/core": "workspace:*",
     "@testing-library/react": "^13.4.0",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
@@ -41,6 +40,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "@signalis/core": "workspace:*"
   }
 }

--- a/packages/react/src/reactor.ts
+++ b/packages/react/src/reactor.ts
@@ -1,6 +1,8 @@
 import { Reaction } from '@signalis/core';
 import { type FunctionComponent, useEffect, useRef, useState } from 'react';
 
+const Empty = [] as const;
+
 function useSignalis<T>(renderFn: () => T): T {
   const [, setState] = useState();
   const forceUpdate = () => {
@@ -26,10 +28,10 @@ function useSignalis<T>(renderFn: () => T): T {
       forceUpdate();
     }
     return () => {
-      reactionRef.current?.dispose();
+      reactionRef.current!.dispose();
       reactionRef.current = null;
     };
-  }, []);
+  }, Empty);
 
   let rendered!: T;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,9 +49,8 @@ importers:
       jsdom: ^20.0.3
       react: ^18.2.0
       react-dom: ^18.2.0
-    dependencies:
-      '@signalis/core': link:../core
     devDependencies:
+      '@signalis/core': link:../core
       '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9


### PR DESCRIPTION
- unlink observers on reaction dispose
- don’t reallocate array for every use effect
- make core a peer dep
