### PR TITLE
allow returning a cleanup fn from effect cb

### DIFF
--- a/packages/core/src/effect.ts
+++ b/packages/core/src/effect.ts
@@ -1,9 +1,9 @@
 import { Reaction } from './reaction.js';
 
-export function createEffect(fn: () => void, cleanup?: () => void): () => void {
+export function createEffect(fn: () => void | (() => void)): () => void {
   const effect = new Reaction(function (this: Reaction) {
-    this.trap(fn);
-  }, cleanup);
+    return this.trap(fn);
+  });
 
   effect.compute();
 

--- a/packages/core/tests/effect.spec.ts
+++ b/packages/core/tests/effect.spec.ts
@@ -171,15 +171,17 @@ describe('Effect', () => {
 
     let didCleanup = false;
 
-    const effectSpy = vi.fn(() => {
-      foo.value;
-    });
-
     const cleanupSpy = vi.fn(() => {
       didCleanup = true;
     });
 
-    const dispose = createEffect(effectSpy, cleanupSpy);
+    const effectSpy = vi.fn(() => {
+      foo.value;
+
+      return cleanupSpy;
+    });
+
+    const dispose = createEffect(effectSpy);
 
     foo.value++;
 


### PR DESCRIPTION
Change `createEffect` so that you specify a cleanup function by returning it from the effect callback rather than passing it a separate argument. This is a valuable change because it allows cleanup functions to access things that are created in the scope of the callback function (e.g. clearing an interval created with `setInterval` in the effect.