### PR TITLE
`useSignalEffect` + bug fix for `spliceWhenKnown`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "pnpm -r test",
     "build": "pnpm build:ts && pnpm build:types",
     "build:ts": "pnpm --filter core --filter react run build",
-    "build:types": "pnpm --filter core --filter react run build:types"
+    "build:types": "pnpm --filter core --filter react run build:types",
+    "release": "pnpm -r public --access public"
   },
   "keywords": [],
   "author": "Chris Freeman",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalis/core",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "",
   "type": "module",
   "files": [

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -9,7 +9,7 @@ export function unlinkObservers(target: Derived<unknown> | Reaction) {
   }
   for (let i = 0; i < sources.length; i++) {
     const source = sources[i] as Signal<unknown> | Derived<unknown>;
-    if (!source._observers) {
+    if (!source._observers || source._observers.length === 0) {
       return;
     }
     spliceWhenKnown(source._observers, target);
@@ -19,6 +19,13 @@ export function unlinkObservers(target: Derived<unknown> | Reaction) {
 function spliceWhenKnown<T>(array: Array<T>, target: T): Array<T> {
   const idx = array.findIndex((v) => v === target);
   assert(idx !== -1, 'item must be in the array');
+  // Since `assert` gets stripped in prod builds, we want to still handle the case where we don't
+  // find a match. If we don't return early here, we end up setting the target on the index `-1`
+  // and then calling `pop`, which leaves us with an array of length 0...with a `-1` property
+  // containing the observer :sob:
+  if (idx === -1) {
+    return array;
+  }
 
   const last = array[array.length - 1];
   assert(!!last); // array cannot be empty *and* idx not be set!

--- a/packages/react-dummy-app/index.html
+++ b/packages/react-dummy-app/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>

--- a/packages/react-dummy-app/package.json
+++ b/packages/react-dummy-app/package.json
@@ -9,14 +9,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@data-eden/cache": "^0.2.2-beta.1",
+    "@data-eden/network": "^0.2.2-beta.1",
+    "@signalis/core": "workspace:*",
+    "@signalis/react": "workspace:*",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "@signalis/react": "workspace:*"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.24",
     "@types/react-dom": "^18.0.8",
     "@vitejs/plugin-react": "^2.2.0",
+    "miragejs": "^0.1.47",
     "typescript": "^4.6.4",
     "vite": "^3.2.3"
   }

--- a/packages/react-dummy-app/src/App.tsx
+++ b/packages/react-dummy-app/src/App.tsx
@@ -1,13 +1,15 @@
-import Counter from './Counter';
+// import Counter from './Counter';
 // import Stopwatch from './Stopwatch';
-import Basic from './Basic';
+// import Basic from './Basic';
+import DataExample from './DataEden';
 
 function App() {
   return (
     <div>
-      <Counter></Counter>
+      {/* <Counter></Counter> */}
       {/* <Stopwatch /> */}
       {/* <Basic></Basic> */}
+      <DataExample />
     </div>
   );
 }

--- a/packages/react-dummy-app/src/DataEden.tsx
+++ b/packages/react-dummy-app/src/DataEden.tsx
@@ -13,7 +13,7 @@ const cachedFetch = buildCachedFetch();
 
 const DisplayPersonBase = () => {
   const [loading, setLoading] = useState(false);
-  const [person, setPerson] = useState();
+  const [person, setPerson] = useState<Person>();
 
   useEffect(() => {
     setLoading(true);

--- a/packages/react-dummy-app/src/DataEden.tsx
+++ b/packages/react-dummy-app/src/DataEden.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { buildCachedFetch } from './fetch';
+import { reactor } from '@signalis/react';
+import { makeServer } from './server';
+
+interface Person {
+  name: string;
+}
+
+makeServer();
+
+const cachedFetch = buildCachedFetch();
+
+const DisplayPersonBase = () => {
+  const [loading, setLoading] = useState(false);
+  const [person, setPerson] = useState();
+
+  useEffect(() => {
+    setLoading(true);
+    cachedFetch('/api/users/1')
+      .then((res) => {
+        setPerson(res);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div>
+      <h1>Display Person 1</h1>
+      {loading && <span>Loading...</span>}
+      {person && <span>Name: {person.name}</span>}
+    </div>
+  );
+};
+
+DisplayPersonBase.displayName = 'DisplayPerson';
+
+const DisplayPerson = reactor(DisplayPersonBase);
+
+const UpdatePersonBase = () => {
+  const [inputValue, setInputValue] = useState('');
+
+  function handleInputChange(e: React.FormEvent<HTMLInputElement>) {
+    setInputValue(e.currentTarget.value);
+  }
+
+  function handleSubmit() {
+    cachedFetch('/api/users/1', {
+      method: 'PUT',
+      body: JSON.stringify({ name: inputValue }),
+    }).then(() => {
+      setInputValue('');
+    });
+  }
+
+  return (
+    <div>
+      <h1>Update Person 1</h1>
+      <input type="text" value={inputValue} onChange={handleInputChange} />
+      <button type="button" onClick={handleSubmit}>
+        Submit
+      </button>
+    </div>
+  );
+};
+
+UpdatePersonBase.displayName = 'UpdatePerson';
+
+const UpdatePerson = reactor(UpdatePersonBase);
+// const UpdatePerson = UpdatePersonBase;
+
+function DataExample() {
+  return (
+    <div>
+      <DisplayPerson />
+      <UpdatePerson />
+    </div>
+  );
+}
+
+export default DataExample;

--- a/packages/react-dummy-app/src/Stopwatch.tsx
+++ b/packages/react-dummy-app/src/Stopwatch.tsx
@@ -1,4 +1,5 @@
-import { createDerived, createSignal, reactor } from '@signalis/react';
+import { createDerived, createSignal, createEffect } from '@signalis/core';
+import { reactor, useSignalEffect } from '@signalis/react';
 import { useEffect } from 'react';
 
 function createStopwatch() {
@@ -42,6 +43,10 @@ function Stopwatch() {
 
     return stop;
   }, []);
+
+  useSignalEffect(() => {
+    console.log(timer.value);
+  });
 
   return <div>{timer.value}</div>;
 }

--- a/packages/react-dummy-app/src/fetch.ts
+++ b/packages/react-dummy-app/src/fetch.ts
@@ -1,0 +1,84 @@
+import { buildCache } from '@data-eden/cache';
+import { buildFetch } from '@data-eden/network';
+import { createSignal } from '@signalis/core';
+
+async function loggerMiddleware(
+  request: Request,
+  next: (request: Request) => Promise<Response>
+): Promise<Response> {
+  console.log('request happening!');
+  return next(request);
+}
+
+function getUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+
+  if ('url' in input) {
+    return input.url;
+  }
+
+  return input.toString();
+}
+
+const SIGNAL = Symbol('data-eden-signal');
+
+function createHandler(): ProxyHandler<any> {
+  return {
+    get(target, prop, receiver) {
+      const result = Reflect.get(target, prop, receiver);
+      if (prop !== SIGNAL) {
+        target[SIGNAL].value;
+      }
+
+      return result;
+    },
+    set(target, prop, value) {
+      const result = Reflect.set(target, prop, value);
+      if (prop !== SIGNAL) {
+        const s = target[SIGNAL];
+        s.value = s.value + 1;
+      }
+
+      return result;
+    },
+  };
+}
+
+export function buildCachedFetch() {
+  const fetch = buildFetch([loggerMiddleware]);
+  const cache = buildCache();
+
+  const SignalCache = new Map<string, any>();
+  const handler = createHandler();
+
+  return async function (input: RequestInfo | URL, init?: RequestInit | undefined) {
+    const key = getUrl(input);
+
+    const res = await fetch(input, init).then((res) => res.json());
+
+    const tx = await cache.beginTransaction();
+    tx.set(key, res);
+    await tx.commit();
+
+    const cacheResult = await cache.get(key);
+
+    let withSignal = SignalCache.get(key);
+
+    if (withSignal === undefined) {
+      const base = {
+        ...cacheResult,
+        [SIGNAL]: createSignal(0),
+      };
+      withSignal = new Proxy(base, handler);
+      // withSignal = createSignal(cacheResult);
+      SignalCache.set(key, withSignal);
+    } else {
+      Object.assign(withSignal, cacheResult);
+      // withSignal.value = cacheResult;
+    }
+
+    return withSignal;
+  };
+}

--- a/packages/react-dummy-app/src/server.ts
+++ b/packages/react-dummy-app/src/server.ts
@@ -1,0 +1,26 @@
+import { createServer } from 'miragejs';
+
+const user = {
+  id: 1,
+  name: 'bob',
+};
+
+export function makeServer() {
+  const server = createServer({
+    routes() {
+      this.namespace = 'api';
+
+      this.get('/users/1', () => {
+        return user;
+      });
+
+      this.put('/users/1', (schema, request) => {
+        const attrs = JSON.parse(request.requestBody);
+
+        return Object.assign(user, attrs);
+      });
+    },
+  });
+
+  return server;
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalis/react",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "type": "module",
   "files": [

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,5 @@
 export { reactor } from './reactor.js';
 export { useDerived } from './useDerived.js';
 export { useSignal } from './useSignal.js';
+export { useSignalEffect } from './useSignalEffect.js';
 export * from '@signalis/core';

--- a/packages/react/src/reactor.ts
+++ b/packages/react/src/reactor.ts
@@ -1,7 +1,6 @@
 import { Reaction } from '@signalis/core';
-import { type FunctionComponent, useEffect, useRef, useState } from 'react';
-
-const Empty = [] as const;
+import { useEffect, useRef, useState, type FunctionComponent } from 'react';
+import { EMPTY } from './empty.js';
 
 function useSignalis<T>(renderFn: () => T): T {
   const [, setState] = useState();
@@ -31,7 +30,7 @@ function useSignalis<T>(renderFn: () => T): T {
       reactionRef.current!.dispose();
       reactionRef.current = null;
     };
-  }, Empty);
+  }, EMPTY);
 
   let rendered!: T;
 

--- a/packages/react/src/useSignalEffect.ts
+++ b/packages/react/src/useSignalEffect.ts
@@ -1,0 +1,11 @@
+import { createEffect } from '@signalis/core';
+import { useCallback, useEffect } from 'react';
+import { EMPTY } from './empty.js';
+
+export function useSignalEffect(fn: () => void | (() => void)): void {
+  const cachedFn = useCallback(fn, EMPTY);
+
+  useEffect(() => {
+    return createEffect(() => cachedFn());
+  }, EMPTY);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,15 +60,22 @@ importers:
 
   packages/react-dummy-app:
     specifiers:
+      '@data-eden/cache': ^0.2.2-beta.1
+      '@data-eden/network': ^0.2.2-beta.1
+      '@signalis/core': workspace:*
       '@signalis/react': workspace:*
       '@types/react': ^18.0.24
       '@types/react-dom': ^18.0.8
       '@vitejs/plugin-react': ^2.2.0
+      miragejs: ^0.1.47
       react: ^18.2.0
       react-dom: ^18.2.0
       typescript: ^4.6.4
       vite: ^3.2.3
     dependencies:
+      '@data-eden/cache': 0.2.2-beta.1
+      '@data-eden/network': 0.2.2-beta.1
+      '@signalis/core': link:../core
       '@signalis/react': link:../react
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -76,6 +83,7 @@ importers:
       '@types/react': 18.0.25
       '@types/react-dom': 18.0.9
       '@vitejs/plugin-react': 2.2.0_vite@3.2.4
+      miragejs: 0.1.47
       typescript: 4.9.3
       vite: 3.2.4
 
@@ -355,6 +363,18 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
+  /@data-eden/cache/0.2.2-beta.1:
+    resolution: {integrity: sha512-QFecHNDv8q7z3OUcKa/86Ny6vInE5ZX3u6sW5dtxTiaF4QBDapx37fLUgquyQMHi2K7toVgomPLyBi09oz6MeQ==}
+    dev: false
+
+  /@data-eden/network/0.2.2-beta.1:
+    resolution: {integrity: sha512-J+BBdD/v3mmDuA3V0k+vKymdpfo6fQNO3fPKXGbRAPokeOCXRzCR0XygG72Zfh9X+4GmZdtL9ezuyj4E/pw1fg==}
+    dependencies:
+      cross-fetch: 3.1.5
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /@esbuild/android-arm/0.15.14:
     resolution: {integrity: sha512-+Rb20XXxRGisNu2WmNKk+scpanb7nL5yhuI1KR9wQFiC43ddPj/V1fmNyzlFC9bKiG4mYzxW7egtoHVcynr+OA==}
     engines: {node: '>=12'}
@@ -446,6 +466,10 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /@miragejs/pretender-node-polyfill/0.1.2:
+    resolution: {integrity: sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==}
     dev: true
 
   /@nodelib/fs.scandir/2.1.5:
@@ -951,6 +975,14 @@ packages:
   /convert-source-map/1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
     dev: true
+
+  /cross-fetch/3.1.5:
+    resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
+    dependencies:
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
+    dev: false
 
   /cross-spawn/7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -1475,6 +1507,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /fake-xml-http-request/2.1.2:
+    resolution: {integrity: sha512-HaFMBi7r+oEC9iJNpc3bvcW7Z7iLmM26hPDmlb0mFwyANSsOQAtJxbdWsXITKOzZUyMYK0zYCv3h5yDj9TsiXg==}
+    dev: true
+
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -1741,6 +1777,10 @@ packages:
     engines: {node: '>=0.8.19'}
     dev: true
 
+  /inflected/2.1.0:
+    resolution: {integrity: sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==}
+    dev: true
+
   /inflight/1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
@@ -1988,8 +2028,100 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash.assign/4.2.0:
+    resolution: {integrity: sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==}
+    dev: true
+
+  /lodash.camelcase/4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+    dev: true
+
+  /lodash.clonedeep/4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+    dev: true
+
+  /lodash.compact/3.0.1:
+    resolution: {integrity: sha512-2ozeiPi+5eBXW1CLtzjk8XQFhQOEMwwfxblqeq6EGyTxZJ1bPATqilY0e6g2SLQpP4KuMeuioBhEnWz5Pr7ICQ==}
+    dev: true
+
+  /lodash.find/4.6.0:
+    resolution: {integrity: sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg==}
+    dev: true
+
+  /lodash.flatten/4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+    dev: true
+
+  /lodash.forin/4.4.0:
+    resolution: {integrity: sha512-APldePP4yvGhMcplVxv9L+exdLHMRHRhH1Q9O70zRJMm9HbTm6zxaihXtNl+ICOBApeFWoH7jNmFr/L4XfWeiQ==}
+    dev: true
+
+  /lodash.get/4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    dev: true
+
+  /lodash.has/4.5.2:
+    resolution: {integrity: sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g==}
+    dev: true
+
+  /lodash.invokemap/4.6.0:
+    resolution: {integrity: sha512-CfkycNtMqgUlfjfdh2BhKO/ZXrP8ePOX5lEU/g0R3ItJcnuxWDwokMGKx1hWcfOikmyOVx6X9IwWnDGlgKl61w==}
+    dev: true
+
+  /lodash.isempty/4.4.0:
+    resolution: {integrity: sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg==}
+    dev: true
+
+  /lodash.isequal/4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    dev: true
+
+  /lodash.isfunction/3.0.9:
+    resolution: {integrity: sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==}
+    dev: true
+
+  /lodash.isinteger/4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+    dev: true
+
+  /lodash.isplainobject/4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+    dev: true
+
+  /lodash.lowerfirst/4.3.1:
+    resolution: {integrity: sha512-UUKX7VhP1/JL54NXg2aq/E1Sfnjjes8fNYTNkPU8ZmsaVeBvPHKdbNaN79Re5XRL01u6wbq3j0cbYZj71Fcu5w==}
+    dev: true
+
+  /lodash.map/4.6.0:
+    resolution: {integrity: sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==}
+    dev: true
+
+  /lodash.mapvalues/4.6.0:
+    resolution: {integrity: sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==}
+    dev: true
+
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: true
+
+  /lodash.pick/4.4.0:
+    resolution: {integrity: sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==}
+    dev: true
+
+  /lodash.snakecase/4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+    dev: true
+
+  /lodash.uniq/4.5.0:
+    resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
+    dev: true
+
+  /lodash.uniqby/4.7.0:
+    resolution: {integrity: sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==}
+    dev: true
+
+  /lodash.values/4.3.0:
+    resolution: {integrity: sha512-r0RwvdCv8id9TUblb/O7rYPwVy6lerCbcawrfdo9iC/1t1wsNMJknO79WNBgwkH0hIeJ08jmvvESbFpNb4jH0Q==}
     dev: true
 
   /lodash/4.17.21:
@@ -2058,6 +2190,38 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
+  /miragejs/0.1.47:
+    resolution: {integrity: sha512-99tuCbIAlMhNhyF3s5d3+5/FdJ7O4jSq/5e3e+sDv7L8dZdwJuwutXe0pobJ7hm6yRChTDjK+Nn8dZZd175wbg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dependencies:
+      '@miragejs/pretender-node-polyfill': 0.1.2
+      inflected: 2.1.0
+      lodash.assign: 4.2.0
+      lodash.camelcase: 4.3.0
+      lodash.clonedeep: 4.5.0
+      lodash.compact: 3.0.1
+      lodash.find: 4.6.0
+      lodash.flatten: 4.4.0
+      lodash.forin: 4.4.0
+      lodash.get: 4.4.2
+      lodash.has: 4.5.2
+      lodash.invokemap: 4.6.0
+      lodash.isempty: 4.4.0
+      lodash.isequal: 4.5.0
+      lodash.isfunction: 3.0.9
+      lodash.isinteger: 4.0.4
+      lodash.isplainobject: 4.0.6
+      lodash.lowerfirst: 4.3.1
+      lodash.map: 4.6.0
+      lodash.mapvalues: 4.6.0
+      lodash.pick: 4.4.0
+      lodash.snakecase: 4.1.1
+      lodash.uniq: 4.5.0
+      lodash.uniqby: 4.7.0
+      lodash.values: 4.3.0
+      pretender: 3.4.7
+    dev: true
+
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
@@ -2075,6 +2239,18 @@ packages:
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
+
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
 
   /node-releases/2.0.6:
     resolution: {integrity: sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==}
@@ -2229,6 +2405,13 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
+  /pretender/3.4.7:
+    resolution: {integrity: sha512-jkPAvt1BfRi0RKamweJdEcnjkeu7Es8yix3bJ+KgBC5VpG/Ln4JE3hYN6vJym4qprm8Xo5adhWpm3HCoft1dOw==}
+    dependencies:
+      fake-xml-http-request: 2.1.2
+      route-recognizer: 0.3.4
+    dev: true
+
   /prettier/2.7.1:
     resolution: {integrity: sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==}
     engines: {node: '>=10.13.0'}
@@ -2339,6 +2522,10 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /route-recognizer/0.3.4:
+    resolution: {integrity: sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==}
     dev: true
 
   /run-parallel/1.2.0:
@@ -2496,6 +2683,10 @@ packages:
       universalify: 0.2.0
       url-parse: 1.5.10
     dev: true
+
+  /tr46/0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
 
   /tr46/3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
@@ -2696,6 +2887,10 @@ packages:
       xml-name-validator: 4.0.0
     dev: true
 
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
   /webidl-conversions/7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -2720,6 +2915,13 @@ packages:
       tr46: 3.0.0
       webidl-conversions: 7.0.0
     dev: true
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: false
 
   /which-boxed-primitive/1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}


### PR DESCRIPTION
This PR adds a new `useSignalEffect` hooking for creating Signalis effects inside react components (similar to `useSignal` and `useDerived`).

It also fixes a bug that could occur when unlinking observers on a target that with no matches (e.g. the target isn't actually one of the observers). Due to JavaScript™, you could end up with an `_observers` array of 0 length...with an observer at the `-1` index, which would never actually get iterated over, and which would break any reactions that relied on it.

This PR also adds a new example to the react dummy app that demonstrates a way to "sidecar" reactivity onto existing objects