### PR TITLE
fix useSignal

### DIFF
--- a/.changeset/sixty-timers-allow.md
+++ b/.changeset/sixty-timers-allow.md
@@ -1,0 +1,5 @@
+---
+'@signalis/react': patch
+---
+
+Fix `useSignal` implementation so empty strings pass through

--- a/packages/react/src/useSignal.ts
+++ b/packages/react/src/useSignal.ts
@@ -5,5 +5,5 @@ import { EMPTY } from './empty.js';
 export function useSignal(value?: null | undefined): Signal<unknown>;
 export function useSignal<T extends {}>(value: T): Signal<T>;
 export function useSignal<T extends {}>(value?: T | null | undefined): Signal<T> | Signal<unknown> {
-  return useMemo(() => (value ? createSignal(value) : createSignal(null)), EMPTY);
+  return useMemo(() => (arguments.length > 0 ? createSignal(value) : createSignal()), EMPTY);
 }


### PR DESCRIPTION
fix `useSignal` so that it will always pass `value` through to the underlying signal