### PR TITLE
don't push duplicate sources into context

### DIFF
--- a/.changeset/wild-zoos-fold.md
+++ b/.changeset/wild-zoos-fold.md
@@ -1,0 +1,5 @@
+---
+'@signalis/core': patch
+---
+
+dedupe compute contexts

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -62,7 +62,11 @@ export function markDependency(v: ReactiveValue): void {
   if (STATE.suspended) {
     return;
   }
+
   if (STATE.currentContext) {
+    if (STATE.currentContext.includes(v)) {
+      return;
+    }
     STATE.currentContext.push(v);
   }
 }


### PR DESCRIPTION
Check if a source is already being observed by a given reaction before adding it as an observer.