### PR TITLE
add `createStore` and `update`

### DIFF
--- a/.changeset/five-stingrays-knock.md
+++ b/.changeset/five-stingrays-knock.md
@@ -1,0 +1,6 @@
+---
+'@signalis/react': patch
+'@signalis/core': patch
+---
+
+add `createStore` and update package keywords

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.tsbuildinfo
 
 packages/core/old-src
+packages/core/__scratch.ts

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,11 @@
     "build:js": "vite build",
     "build:types": "tsc -p tsconfig.build.json"
   },
-  "keywords": [],
+  "keywords": [
+    "reactivity",
+    "signal",
+    "reactive"
+  ],
   "author": "Chris Freeman",
   "license": "MIT",
   "devDependencies": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,3 +5,4 @@ export { batch } from './batch.js';
 export { Reaction, isReaction } from './reaction.js';
 export { createResource, type Resource, type ResourceWithSource } from './resource.js';
 export { createStore } from './store.js';
+export { update } from './update.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@ export { createEffect } from './effect.js';
 export { batch } from './batch.js';
 export { Reaction, isReaction } from './reaction.js';
 export { createResource, type Resource, type ResourceWithSource } from './resource.js';
+export { createStore } from './store.js';

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1,0 +1,136 @@
+import { Signal, createSignal, isSignal } from './signal.js';
+import { traverse } from './utils.js';
+import { untrack } from './untrack.js';
+
+export function isObject(v: any): v is object {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function isGetter(v: PropertyDescriptor | undefined): v is PropertyDescriptor & { get: () => any } {
+  return !!(v && v.get);
+}
+
+const $NODES = Symbol('signal-nodes');
+const $STOREPROXY = Symbol('signal-store-proxy');
+
+type SignalNodeMap = Record<PropertyKey, Signal<unknown>>;
+
+interface Store {
+  [$NODES]: SignalNodeMap;
+  [$STOREPROXY]: Store;
+  [key: PropertyKey]: any;
+}
+
+interface StoreInput {
+  [$NODES]?: SignalNodeMap;
+  [$STOREPROXY]?: Store;
+  [key: PropertyKey]: any;
+}
+
+function getSignalNodes(v: Store): SignalNodeMap {
+  let nodes = v[$NODES];
+  if (!nodes) {
+    nodes = {};
+    Object.defineProperty(v, $NODES, { value: nodes });
+  }
+
+  return nodes;
+}
+function getSignalNode(nodesMap: SignalNodeMap, property: PropertyKey, value: any) {
+  const result = nodesMap[property];
+
+  if (result) {
+    return result;
+  }
+
+  const signal = createSignal(value, false);
+  nodesMap[property] = signal;
+  return signal;
+}
+
+export const handler: ProxyHandler<Store> = {
+  get(target, prop) {
+    const nodes = getSignalNodes(target);
+
+    if (prop === $NODES) {
+      return nodes;
+    }
+
+    const node = nodes[prop];
+
+    let value = node ? node.value : target[prop];
+
+    if (!node) {
+      const descriptor = Object.getOwnPropertyDescriptor(target, prop);
+      if (typeof value !== 'function' && !isGetter(descriptor))
+        value = getSignalNode(nodes, prop, value).value;
+    }
+
+    if (isObject(value)) {
+      return createStore(value);
+    }
+
+    return value;
+  },
+
+  set(target, prop, newValue) {
+    const nodes = getSignalNodes(target);
+
+    const prev = target[prop];
+
+    target[prop] = newValue;
+
+    const node = getSignalNode(nodes, prop, prev);
+
+    node.value = newValue;
+
+    return true;
+  },
+
+  ownKeys(target) {
+    return Reflect.ownKeys(target);
+  },
+
+  getOwnPropertyDescriptor(target, prop) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+    if (!descriptor || prop === $NODES || prop === $STOREPROXY || isGetter(descriptor)) {
+      return descriptor;
+    }
+
+    delete descriptor.value;
+    delete descriptor.writable;
+
+    descriptor.get = () => target[$STOREPROXY][prop];
+
+    return descriptor;
+  },
+};
+
+export function createStore(v: StoreInput) {
+  let proxy = v[$STOREPROXY];
+
+  if (proxy) {
+    return proxy;
+  }
+
+  const keys = Object.keys(v);
+  const descriptors = Object.getOwnPropertyDescriptors(v);
+
+  proxy = new Proxy(v, handler) as Store;
+  Object.defineProperty(v, $STOREPROXY, { value: proxy });
+
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+
+    const descriptor = descriptors[key];
+
+    if (isGetter(descriptor)) {
+      Object.defineProperty(v, key, {
+        get: descriptor.get.bind(proxy),
+        enumerable: !!descriptor.enumerable,
+      });
+    }
+  }
+
+  return proxy;
+}

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1,33 +1,39 @@
-import { Signal, createSignal, isSignal } from './signal.js';
-import { traverse } from './utils.js';
-import { untrack } from './untrack.js';
+import { Signal, createSignal } from './signal.js';
 
-export function isObject(v: any): v is object {
-  return typeof v === 'object' && v !== null && !Array.isArray(v);
+export type NotWrappable = string | number | bigint | symbol | boolean | null | undefined;
+
+export type Wrappable<T> = T extends NotWrappable ? never : T;
+
+export function isWrappable<T>(v: T): v is Wrappable<T>;
+export function isWrappable(v: any) {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    (v[$STOREPROXY] || Array.isArray(v) || Object.getPrototypeOf(v) === Object.prototype)
+  );
 }
 
-function isGetter(v: PropertyDescriptor | undefined): v is PropertyDescriptor & { get: () => any } {
+function isGetter(
+  v: PropertyDescriptor | undefined
+): v is PropertyDescriptor & { get: () => unknown } {
   return !!(v && v.get);
 }
 
-const $NODES = Symbol('signal-nodes');
-const $STOREPROXY = Symbol('signal-store-proxy');
+export const $RAW = Symbol('store-target');
+export const $NODES = Symbol('signal-nodes');
+export const $STOREPROXY = Symbol('signal-store-proxy');
+export const $SELF = Symbol('signal-store-self');
 
 type SignalNodeMap = Record<PropertyKey, Signal<unknown>>;
 
-interface Store {
-  [$NODES]: SignalNodeMap;
-  [$STOREPROXY]: Store;
-  [key: PropertyKey]: any;
-}
-
-interface StoreInput {
+export interface StoreNode {
   [$NODES]?: SignalNodeMap;
-  [$STOREPROXY]?: Store;
   [key: PropertyKey]: any;
 }
 
-function getSignalNodes(v: Store): SignalNodeMap {
+type Store<T> = T;
+
+function getSignalNodes(v: StoreNode): SignalNodeMap {
   let nodes = v[$NODES];
   if (!nodes) {
     nodes = {};
@@ -36,7 +42,8 @@ function getSignalNodes(v: Store): SignalNodeMap {
 
   return nodes;
 }
-function getSignalNode(nodesMap: SignalNodeMap, property: PropertyKey, value: any) {
+
+function getSignalNode(nodesMap: SignalNodeMap, property: PropertyKey, value: unknown) {
   const result = nodesMap[property];
 
   if (result) {
@@ -48,55 +55,89 @@ function getSignalNode(nodesMap: SignalNodeMap, property: PropertyKey, value: an
   return signal;
 }
 
-export const handler: ProxyHandler<Store> = {
-  get(target, prop) {
+function trackSelf(node: StoreNode) {
+  const nodes = getSignalNodes(node);
+  if (!nodes[$SELF]) {
+    (nodes[$SELF] = createSignal()).value;
+  }
+}
+
+export const handler: ProxyHandler<StoreNode> = {
+  get(target, prop, receiver) {
     const nodes = getSignalNodes(target);
+
+    if (prop === $STOREPROXY) {
+      return receiver;
+    }
+
+    if (prop === $RAW) {
+      return target;
+    }
 
     if (prop === $NODES) {
       return nodes;
     }
 
-    const node = nodes[prop];
+    if (prop === $SELF) {
+      trackSelf(target);
+      return receiver;
+    }
+
+    let node = nodes[prop];
 
     let value = node ? node.value : target[prop];
 
     if (!node) {
       const descriptor = Object.getOwnPropertyDescriptor(target, prop);
-      if (typeof value !== 'function' && !isGetter(descriptor))
-        value = getSignalNode(nodes, prop, value).value;
+      if (typeof value !== 'function' && !isGetter(descriptor)) {
+        node = getSignalNode(nodes, prop, value);
+        value = node.value;
+      }
     }
 
-    if (isObject(value)) {
-      return createStore(value);
+    if (isWrappable(value)) {
+      return wrap(value);
     }
 
     return value;
   },
 
-  set(target, prop, newValue) {
-    const nodes = getSignalNodes(target);
+  set() {
+    throw new Error(`Can't set properties directly on stores. Use \`update\` instead.`);
+  },
 
-    const prev = target[prop];
+  has(target, prop) {
+    if (prop === $STOREPROXY || prop === $RAW || prop === $NODES) {
+      return true;
+    }
 
-    target[prop] = newValue;
+    this.get!(target, prop, target);
 
-    const node = getSignalNode(nodes, prop, prev);
-
-    node.value = newValue;
-
-    return true;
+    return prop in target;
   },
 
   ownKeys(target) {
+    trackSelf(target);
     return Reflect.ownKeys(target);
   },
 
   getOwnPropertyDescriptor(target, prop) {
     const descriptor = Reflect.getOwnPropertyDescriptor(target, prop);
-    if (!descriptor || prop === $NODES || prop === $STOREPROXY || isGetter(descriptor)) {
+    if (
+      !descriptor ||
+      !descriptor.configurable ||
+      prop === $NODES ||
+      prop === $STOREPROXY ||
+      prop === $SELF ||
+      isGetter(descriptor)
+    ) {
       return descriptor;
     }
 
+    // if we're here, it means we're looking for the property descriptor of a value that should be
+    // be wrapped. Since we want delegate any property access to the proxy, we convert the
+    // descriptor from a data descriptor into an accessor descriptor whose getter returns the
+    // value from the proxy.
     delete descriptor.value;
     delete descriptor.writable;
 
@@ -106,31 +147,124 @@ export const handler: ProxyHandler<Store> = {
   },
 };
 
-export function createStore(v: StoreInput) {
+// `setProperty` manages the bookkeeping involved in updating a property on a store. It handles
+// updating the property on both the underlying object and on the reactive wrapper that gets
+// returned on property access. If the property hasn't been wrapped yet, we wrap it here before
+// updating it.
+export function setProperty(target: StoreNode, prop: PropertyKey, value: unknown) {
+  const nodes = getSignalNodes(target);
+  const length = target.length;
+
+  const prev = target[prop];
+
+  if (value === undefined) {
+    delete target[prop];
+  } else {
+    target[prop] = value;
+  }
+
+  let node = getSignalNode(nodes, prop, prev);
+
+  node.value = value;
+
+  if (Array.isArray(target) && target.length !== length) {
+    // Need to make sure we keep the lengths of arrays in sync between the underlying object
+    // and the store node. By making an array's `length` property a signal node, we ensure that
+    // its length is reactive and can be subscribed to
+    node = getSignalNode(nodes, 'length', length);
+    node.value = target.length;
+  }
+
+  // If this node is tracking itself, we poke the underlying signal to indicate that something
+  // on it has changed.
+  if (nodes[$SELF]) {
+    nodes[$SELF].value = null;
+  }
+}
+
+function wrap<T extends StoreNode>(v: T): T {
   let proxy = v[$STOREPROXY];
 
   if (proxy) {
-    return proxy;
+    return proxy as T;
   }
 
-  const keys = Object.keys(v);
-  const descriptors = Object.getOwnPropertyDescriptors(v);
-
-  proxy = new Proxy(v, handler) as Store;
+  proxy = new Proxy(v, handler);
   Object.defineProperty(v, $STOREPROXY, { value: proxy });
 
-  for (let i = 0; i < keys.length; i++) {
-    const key = keys[i];
+  if (!Array.isArray(v)) {
+    const keys = Object.keys(v);
+    const descriptors = Object.getOwnPropertyDescriptors(v);
 
-    const descriptor = descriptors[key];
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
 
-    if (isGetter(descriptor)) {
-      Object.defineProperty(v, key, {
-        get: descriptor.get.bind(proxy),
-        enumerable: !!descriptor.enumerable,
-      });
+      const descriptor = descriptors[key];
+
+      // re-bind any getters to the proxy instead of the undlerying object
+      if (isGetter(descriptor)) {
+        Object.defineProperty(v, key, {
+          get: descriptor.get.bind(proxy),
+          enumerable: !!descriptor.enumerable,
+        });
+      }
     }
   }
 
-  return proxy;
+  return proxy as T;
+}
+
+// revert a store back to its non-reactive version. the result of `unwrap` is referentially identical
+// to the original object that was passed to `createStore`
+export function unwrap<T>(v: T, set?: Set<unknown>): T;
+export function unwrap<T>(v: any, set = new Set()): T {
+  let len, value, key: keyof typeof v;
+  if (v != null && v[$RAW]) {
+    return v[$RAW];
+  }
+
+  // If we couldn't have wrapped this in the first place *or* we've already unwrapped this value,
+  // just return it as is
+  if (!isWrappable(v) || set.has(v)) {
+    return v;
+  }
+
+  // Track this value as having already been seen so we don't blow up if we encounter a cycle
+  set.add(v);
+
+  // unwrap each member of an array or object and replace it in the original object (this is how
+  // we maintain reference stability)
+  if (Array.isArray(v)) {
+    len = v.length;
+    for (let i = 0; i < len; i++) {
+      value = v[i];
+
+      const unwrapped = unwrap(value, set);
+      if (unwrapped !== value) {
+        v[i] = unwrapped;
+      }
+    }
+  } else {
+    const keys = Object.keys(v);
+    const descriptors = Object.getOwnPropertyDescriptors(v);
+
+    len = keys.length;
+    for (let i = 0; i < len; i++) {
+      key = keys[i];
+      if (!isGetter(descriptors[key])) {
+        value = v[key];
+        const unwrapped = unwrap(value, set);
+        if (unwrapped !== value) {
+          v[key] = unwrapped;
+        }
+      }
+    }
+  }
+
+  return v;
+}
+
+export function createStore<T extends object>(v: T | Store<T>): Store<T> {
+  const unwrapped = unwrap(v);
+  return wrap(unwrapped);
 }

--- a/packages/core/src/update.ts
+++ b/packages/core/src/update.ts
@@ -1,0 +1,70 @@
+import { batch } from './batch.js';
+import { $RAW, type StoreNode, isWrappable, setProperty, unwrap, type Wrappable } from './store.js';
+
+const UpdaterMap = new WeakMap<Wrappable<StoreNode>, Wrappable<StoreNode>>();
+
+/**
+ * `update` works by wrapping a store's underlying object in a new proxy that does two main things:
+ * 1. Traps all write operations, unwraps the incoming value in case it's a store, and delegates the
+ *  write to `setProperty`, which handles updating properties in stores
+ * 2. Traps all read operations and makes sure that any properties that are accessed are also wrapped
+ * in their own version of this proxy
+ *
+ * This proxy is the `draft` that then gets passed to the callback passed in as `update`'s second
+ * argument. By managing all the writes and reads and delegating them to their respective store nodes,
+ * we're able to allow users to mutate a draft object in whatever ways they like and then propagate
+ * those changes to the store.
+ */
+const handler: ProxyHandler<StoreNode> = {
+  get(target, prop) {
+    if (prop === $RAW) {
+      return target;
+    }
+    const value = target[prop];
+
+    if (isWrappable(value)) {
+      let updater = UpdaterMap.get(value);
+
+      if (!updater) {
+        UpdaterMap.set(value, (updater = new Proxy(value, handler)));
+      }
+
+      return updater;
+    } else {
+      return value;
+    }
+  },
+
+  set(target, prop, value) {
+    setProperty(target, prop, unwrap(value));
+    return true;
+  },
+
+  deleteProperty(target, property) {
+    setProperty(target, property, undefined);
+    return true;
+  },
+
+  getOwnPropertyDescriptor(target, prop) {
+    return Reflect.getOwnPropertyDescriptor(target, prop);
+  },
+};
+
+export function update<T extends object>(base: T, recipe: (draft: T) => void): T {
+  if (isWrappable(base)) {
+    let proxy: StoreNode | undefined;
+
+    if (!(proxy = UpdaterMap.get(base))) {
+      UpdaterMap.set(base, (proxy = new Proxy(unwrap(base), handler)));
+    }
+
+    batch(() => {
+      // We know that the proxy exists here because of the if statement above
+      // and we cast it to T because the draft that gets passed to `recipe` is functionally
+      // identical to `base` due to how the Proxy behaves
+      recipe(proxy! as T);
+    });
+  }
+
+  return base;
+}

--- a/packages/core/tests/store.spec.ts
+++ b/packages/core/tests/store.spec.ts
@@ -1,6 +1,7 @@
-import { describe, test, expect, vi } from 'vitest';
-import { createStore } from '../src/store.js';
+import { describe, expect, test, vi } from 'vitest';
 import { createEffect } from '../src/effect.js';
+import { update } from '../src/update.js';
+import { createStore, unwrap, setProperty } from '../src/store.js';
 
 describe('store', () => {
   describe('object behaviors', () => {
@@ -55,12 +56,12 @@ describe('store', () => {
 
       createEffect(spy);
 
-      store.foo = 'baz';
+      setProperty(unwrap(store), 'foo', 'baz');
 
       expect(spy).toHaveBeenCalledTimes(2);
     });
 
-    test.only('getter', () => {
+    test('getter', () => {
       const store = createStore({
         firstName: 'foo',
         lastName: 'bar',
@@ -71,9 +72,79 @@ describe('store', () => {
 
       expect(store.fullName).toEqual('foo bar');
 
-      store.firstName = 'FOO';
+      setProperty(unwrap(store), 'firstName', 'FOO');
 
       expect(store.fullName).toEqual('FOO bar');
+    });
+
+    test('method', () => {
+      let count = 0;
+      const store = createStore({
+        numbers: [],
+
+        boolean: {
+          isTrue: true,
+        },
+
+        addThing() {
+          update(this, (draft) => {
+            draft.numbers = [...draft.numbers, count];
+          });
+          count++;
+        },
+
+        toggleBoolean() {
+          update(this, (draft) => {
+            draft.boolean.isTrue = !draft.boolean.isTrue;
+          });
+        },
+      });
+
+      expect(store.numbers).toEqual([]);
+
+      store.addThing();
+
+      expect(store.numbers).toEqual([0]);
+
+      expect(store.boolean.isTrue).toBe(true);
+
+      store.toggleBoolean();
+
+      expect(store.boolean.isTrue).toBe(false);
+    });
+
+    test('array properties', () => {
+      const store = createStore({
+        foo: [1, 2, 3],
+      });
+
+      const effectSpy = vi.fn(() => {
+        store.foo.length;
+      });
+
+      createEffect(effectSpy);
+
+      expect(effectSpy).toHaveBeenCalledOnce();
+
+      setProperty(unwrap(store), 'foo', [...store.foo, 4]);
+
+      expect(effectSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('array root', () => {
+      const store = createStore([1, 2, 3]);
+
+      const effectSpy = vi.fn(() => {
+        store.length;
+      });
+
+      createEffect(effectSpy);
+
+      expect(effectSpy).toHaveBeenCalledOnce();
+
+      setProperty(unwrap(store), store.length, 4);
+
+      expect(effectSpy).toHaveBeenCalledTimes(2);
     });
 
     test('nested objects', () => {
@@ -115,13 +186,188 @@ describe('store', () => {
         nameEffectCount++;
       });
 
-      store.car.make = 'Honda';
+      update(store, (draft) => {
+        draft.car.make = 'Honda';
+      });
 
       expect(carEffectCount).toEqual(2);
 
-      store.name = 'blah';
+      update(store, (draft) => {
+        draft.name = 'blah';
+      });
 
       expect(nameEffectCount).toEqual(2);
+    });
+
+    test('keys', () => {
+      const store = createStore({
+        foo: 1,
+        bar: {},
+      });
+
+      const effectSpy = vi.fn(() => {
+        Object.keys(store.bar);
+      });
+
+      createEffect(effectSpy);
+
+      update(store, (draft) => {
+        draft.bar.baz = 2;
+      });
+
+      expect(effectSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('entries', () => {
+      const store = createStore({
+        foo: 1,
+        bar: {},
+      });
+
+      const effectSpy = vi.fn(() => {
+        Object.entries(store.bar);
+      });
+
+      createEffect(effectSpy);
+
+      update(store, (draft) => {
+        draft.bar.baz = 2;
+      });
+
+      expect(effectSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test('values', () => {
+      const store = createStore({
+        foo: 1,
+        bar: {},
+      });
+
+      const effectSpy = vi.fn(() => {
+        Object.values(store.bar);
+      });
+
+      createEffect(effectSpy);
+
+      update(store, (draft) => {
+        draft.bar.baz = 2;
+      });
+
+      expect(effectSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('unwrap', () => {
+    test('it works', () => {
+      const base = {
+        foo: 'foo',
+      };
+      const store = createStore(base);
+      const unwrapped = unwrap(store);
+      expect(unwrapped === base).toBe(true);
+    });
+  });
+
+  describe('update', () => {
+    test('flat object', () => {
+      const store = createStore({
+        foo: 'string',
+        bar: 'bar',
+      });
+
+      update(store, (draft) => {
+        draft.foo = 'foo';
+      });
+
+      expect(store.foo).toEqual('foo');
+    });
+
+    test('object property', () => {
+      const store = createStore({
+        foo: {
+          bar: 'baz',
+        },
+      });
+
+      const effectSpy = vi.fn(() => {
+        store.foo.baz;
+        store.foo.bar;
+      });
+
+      createEffect(effectSpy);
+
+      update(store, (draft) => {
+        draft.foo.bar = 'blah';
+        draft.foo.baz = 'baz';
+      });
+
+      expect(effectSpy).toHaveBeenCalledTimes(2);
+
+      expect(store.foo.bar).toEqual('blah');
+      expect(store.foo.baz).toEqual('baz');
+
+      update(store, (draft) => {
+        Object.assign(draft.foo, { bar: 'bar' });
+      });
+
+      expect(effectSpy).toHaveBeenCalledTimes(3);
+    });
+
+    test('array property', () => {
+      const store = createStore({
+        foo: ['foo'],
+      });
+
+      const effectSpy = vi.fn(() => {
+        store.foo.length;
+      });
+
+      createEffect(effectSpy);
+
+      update(store, (draft) => {
+        draft.foo.push('bar');
+      });
+
+      expect(store.foo).toEqual(['foo', 'bar']);
+      expect(effectSpy).toHaveBeenCalledTimes(2);
+
+      update(store, (draft) => {
+        draft.foo[0] = 'FOO';
+      });
+
+      expect(store.foo).toEqual(['FOO', 'bar']);
+    });
+
+    test('delete property', () => {
+      const store = createStore({
+        foo: 'foo',
+        bar: {
+          name: 'bar',
+        },
+      });
+
+      const result = update(store, (draft) => {
+        delete draft.foo;
+      });
+
+      expect(store).not.toHaveProperty('foo');
+
+      expect(store).toEqual(result);
+      expect(store).toEqual({
+        bar: {
+          name: 'bar',
+        },
+      });
+
+      update(store, (draft) => {
+        delete draft.bar.name;
+      });
+
+      expect(store).toEqual({
+        bar: {},
+      });
+
+      expect(store.bar).not.toHaveProperty('name');
     });
   });
 });

--- a/packages/core/tests/store.spec.ts
+++ b/packages/core/tests/store.spec.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect, vi } from 'vitest';
+import { createStore } from '../src/store.js';
+import { createEffect } from '../src/effect.js';
+
+describe('store', () => {
+  describe('object behaviors', () => {
+    const base = {
+      foo: {
+        bar: 'baz',
+        baq: [1, 2, 3],
+      },
+    };
+
+    const store = createStore(base);
+
+    test('keys', () => {
+      const keys = Object.keys(store);
+      expect(keys).toEqual(['foo']);
+    });
+
+    test('entries', () => {
+      const entries = Object.entries(store);
+
+      expect(entries).toEqual([
+        [
+          'foo',
+          {
+            bar: 'baz',
+            baq: [1, 2, 3],
+          },
+        ],
+      ]);
+    });
+
+    test('in', () => {
+      expect('foo' in store).toEqual(true);
+    });
+
+    test('stringify', () => {
+      const stringified = JSON.stringify(store);
+
+      expect(stringified).toEqual(JSON.stringify(base));
+    });
+  });
+
+  describe('reactivity', () => {
+    test('primitive object properties', () => {
+      const store = createStore({
+        foo: 'bar',
+      });
+
+      const spy = vi.fn(() => {
+        store.foo;
+      });
+
+      createEffect(spy);
+
+      store.foo = 'baz';
+
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    test.only('getter', () => {
+      const store = createStore({
+        firstName: 'foo',
+        lastName: 'bar',
+        get fullName() {
+          return `${this.firstName} ${this.lastName}`;
+        },
+      });
+
+      expect(store.fullName).toEqual('foo bar');
+
+      store.firstName = 'FOO';
+
+      expect(store.fullName).toEqual('FOO bar');
+    });
+
+    test('nested objects', () => {
+      const store = createStore({
+        name: 'Chris',
+        car: {
+          make: 'Ford',
+          model: 'Mustang',
+        },
+        pets: [
+          {
+            name: 'Hitch',
+          },
+          {
+            name: 'Dre',
+          },
+        ],
+      });
+
+      expect(store.name).toEqual('Chris');
+      expect(store.car).toEqual({
+        make: 'Ford',
+        model: 'Mustang',
+      });
+      expect(store.pets[0]).toEqual({
+        name: 'Hitch',
+      });
+
+      let carEffectCount = 0;
+      let nameEffectCount = 0;
+
+      createEffect(() => {
+        store.car.make;
+        carEffectCount++;
+      });
+
+      createEffect(() => {
+        store.name;
+        nameEffectCount++;
+      });
+
+      store.car.make = 'Honda';
+
+      expect(carEffectCount).toEqual(2);
+
+      store.name = 'blah';
+
+      expect(nameEffectCount).toEqual(2);
+    });
+  });
+});

--- a/packages/react-dummy-app/src/todos/TodoList.tsx
+++ b/packages/react-dummy-app/src/todos/TodoList.tsx
@@ -8,7 +8,7 @@ interface TodoItemProps {
   handleRemove: (id: number) => void;
 }
 
-function TodoItem({ todo, handleCheck, handleRemove }: TodoItemProps) {
+const TodoItem = reactor(({ todo, handleCheck, handleRemove }: TodoItemProps) => {
   const toggleCheckbox = () => {
     handleCheck(todo.id);
   };
@@ -49,7 +49,9 @@ function TodoItem({ todo, handleCheck, handleRemove }: TodoItemProps) {
       </div>
     </li>
   );
-}
+});
+
+TodoItem.displayName = 'TodoItem';
 
 interface StatusPickerItemProps {
   status: string;
@@ -138,16 +140,16 @@ NewTodo.displayName = 'NewTodo';
 function TodoList() {
   const currentStatus = useSignal('All');
 
-  const todosList = useDerived(() => {
+  const todoList = useDerived(() => {
     if (currentStatus.value === 'Incomplete') {
-      return store.todos.value.filter((todo) => !todo.complete);
+      return store.todos.filter((todo) => !todo.complete);
     }
 
     if (currentStatus.value === 'Complete') {
-      return store.todos.value.filter((todo) => todo.complete);
+      return store.todos.filter((todo) => todo.complete);
     }
 
-    return store.todos.value;
+    return store.todos;
   });
 
   const toggleComplete = (id: number) => store.toggleComplete(id);
@@ -162,7 +164,7 @@ function TodoList() {
         updateStatus={(status: string) => (currentStatus.value = status)}
       />
       <ul className="pt-4">
-        {todosList.value.map((todo) => {
+        {todoList.value.map((todo) => {
           return (
             <TodoItem
               key={todo.id}

--- a/packages/react-dummy-app/src/todos/TodoStore.ts
+++ b/packages/react-dummy-app/src/todos/TodoStore.ts
@@ -1,46 +1,9 @@
-import { type Signal, createDerived, createSignal } from '@signalis/react';
-import { produce } from 'immer';
+import { createStore, update } from '@signalis/react';
 
 export interface Todo {
   id: number;
   text: string;
   complete: boolean;
-}
-
-class TodoStore {
-  todos: Signal<Array<Todo>> = createSignal([]);
-  currentMaxId = createDerived(() => Math.max(...this.todos.value.map((todo) => todo.id)));
-
-  constructor(todos?: Array<Todo>) {
-    if (todos) {
-      this.todos.value = todos;
-    }
-  }
-
-  addTodo(todoValue: string) {
-    this.todos.value = produce(this.todos.value, (draft) => {
-      draft.push({
-        id: this.currentMaxId.value + 1,
-        text: todoValue,
-        complete: false,
-      });
-    });
-  }
-
-  removeTodo(id: number) {
-    this.todos.value = produce(this.todos.value, (draft) => {
-      const toRemove = draft.findIndex((v) => v.id === id);
-      draft.splice(toRemove, 1);
-    });
-  }
-
-  toggleComplete(id: number) {
-    this.todos.value = produce(this.todos.value, (draft) => {
-      const toUpdate = draft.findIndex((v) => v.id === id);
-      const currentStatus = draft[toUpdate].complete;
-      draft[toUpdate].complete = !currentStatus;
-    });
-  }
 }
 
 const initialTodos = [
@@ -56,4 +19,34 @@ const initialTodos = [
   },
 ];
 
-export const store = new TodoStore(initialTodos);
+export const store = createStore({
+  todos: initialTodos,
+
+  get currentMaxId() {
+    return Math.max(...this.todos.map((todo: Todo) => todo.id));
+  },
+
+  addTodo(todoValue: string) {
+    update(this.todos, (draft) => {
+      draft.push({
+        id: this.currentMaxId + 1,
+        text: todoValue,
+        complete: false,
+      });
+    });
+  },
+
+  removeTodo(id: number) {
+    update(this.todos, (draft) => {
+      const toRemove = draft.findIndex((v) => v.id === id);
+      draft.splice(toRemove, 1);
+    });
+  },
+
+  toggleComplete(id: number) {
+    update(this.todos, (draft) => {
+      const toUpdate = draft.findIndex((v) => v.id === id);
+      draft[toUpdate].complete = !draft[toUpdate].complete;
+    });
+  },
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,7 +25,12 @@
     "build": "vite build",
     "build:types": "tsc -p tsconfig.build.json"
   },
-  "keywords": [],
+  "keywords": [
+    "reactivity",
+    "signal",
+    "react",
+    "state management"
+  ],
   "author": "Chris Freeman",
   "license": "MIT",
   "dependencies": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,6 +2,7 @@
   "extends": "@tsconfig/node-lts-strictest",
   "compilerOptions": {
     "noPropertyAccessFromIndexSignature": false,
+    "noUncheckedIndexedAccess": false,
     "sourceMap": true,
     "target": "ESNext",
     "module": "Node16",


### PR DESCRIPTION
Introduce a new `store` abstraction for managing more complex state. Heavily inspired by [SolidJS](https://www.solidjs.com/docs/latest/api#using-stores) and adapted to work better with Signalis' existing API.