### PR TITLE
dependency optimization

### DIFF
--- a/.changeset/wicked-icons-allow.md
+++ b/.changeset/wicked-icons-allow.md
@@ -1,0 +1,5 @@
+---
+'@signalis/core': patch
+---
+
+optimize dependency reconciliation

--- a/packages/core/src/signal.ts
+++ b/packages/core/src/signal.ts
@@ -19,6 +19,7 @@ export class _Signal<T> {
   readonly type = SignalTag;
   private _value: T;
   private _isEqual: Equality<T>;
+
   /**
    * @internal
    */

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -71,11 +71,9 @@ export function markDependency(v: ReactiveValue): void {
   }
 }
 
-function runUpdatesForObserver(source: ReactiveValue, status: NOTCLEAN) {
-  if (source._observers) {
-    for (let i = 0; i < source._observers.length; i++) {
-      source._observers[i]?.markUpdate(status);
-    }
+function runUpdatesForObserver(observers: Array<ReactiveFunction>, status: NOTCLEAN) {
+  for (let i = 0; i < observers.length; i++) {
+    observers[i]?.markUpdate(status);
   }
 }
 
@@ -83,11 +81,10 @@ function runUpdatesForObserver(source: ReactiveValue, status: NOTCLEAN) {
 // the status update will instead be deferred until the batch is done.
 export function markUpdates(source: ReactiveValue, status: NOTCLEAN): void {
   if (source._observers) {
-    const inBatch = batchCount() !== 0;
-    if (inBatch) {
-      STATE.pendingUpdates.set(source, () => runUpdatesForObserver(source, status));
+    if (batchCount() !== 0) {
+      STATE.pendingUpdates.set(source, () => runUpdatesForObserver(source._observers!, status));
     } else {
-      runUpdatesForObserver(source, status);
+      runUpdatesForObserver(source._observers, status);
     }
   }
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,17 +1,19 @@
 import type { Derived } from './derived.js';
-import type { Reaction } from './reaction.js';
 import type { Signal } from './signal.js';
+import { getContextIndex, getCurrentContext } from './state.js';
+import type { ReactiveFunction } from './types.js';
 
 // Remove a given ReactiveFunction from all of its sources' observer arrays. In essence, this breaks
 // the link between a ReactiveFunction and all of its sources. We use this to "reset" a
 // ReactiveFunction's dependencies prior to re-computing it in order to ensure that we don't
 // leak dependencies between computations
-export function unlinkObservers(target: Derived<unknown> | Reaction) {
+export function unlinkObservers(target: ReactiveFunction) {
   const { _sources: sources } = target;
   if (!sources) {
     return;
   }
-  for (let i = 0; i < sources.length; i++) {
+
+  for (let i = getContextIndex(); i < sources.length; i++) {
     const source = sources[i] as Signal<unknown> | Derived<unknown>;
     if (!source._observers || source._observers.length === 0) {
       return;
@@ -43,5 +45,55 @@ function spliceWhenKnown<T>(array: Array<T>, target: T): Array<T> {
 export function assert(condition: any, msg?: string): asserts condition {
   if (!condition) {
     throw new Error(msg);
+  }
+}
+
+// This function is responsible for all of the bookkeeping we need to do after running a reactive
+// computation in order to correctly track/update all of a computation's dependencies. Highly
+// influenced by Reactively's extremely clever optimization work here https://github.com/modderme123/reactively/commit/fde309bb2966e5d382868169f9b8905532596ec5#diff-f63fb32fca85d8e177d6400ce078818a4815b80ac7a3319b60d3507354890992
+export function reconcileSources(node: ReactiveFunction) {
+  const context = getCurrentContext();
+  const idx = getContextIndex();
+
+  // If a current context exists, it means we encountered at least one dependency that has changed
+  // (or that it's the very first run of the reactive function)
+  if (context) {
+    unlinkObservers(node);
+
+    // if the node already has sources but the context index is > 0, it means that the node's list
+    // of dependencies is partially unchanged (from the first spot up to wherever the context index
+    // is) but then diverged once we hit the context index. In this case, we update the node's
+    // sources by adjusting its size and then filling it from the context index forward
+    if (node._sources && idx > 0) {
+      node._sources.length = idx + context.length;
+
+      for (let i = 0; i < context.length; i++) {
+        node._sources[idx + i] = context[i]!;
+      }
+    } else {
+      // in this case, we either didn't have any sources before, or they changed so completely
+      // that we couldn't share any with the previous run, so we just overwrite the whole thing
+      node._sources = context;
+    }
+
+    // add ourselves to each new/changed source's list of observers now
+    for (let i = idx; i < node._sources.length; i++) {
+      const source = node._sources[i];
+      if (source) {
+        if (source._observers) {
+          source._observers.push(node);
+        } else {
+          source._observers = [node];
+        }
+      }
+    }
+  } else if (node._sources && idx < node._sources.length) {
+    // if we're here, it's because the number of sources we referenced during the computation
+    // (essentially the context index) is less than the current number of sources, which means
+    // that while we didn't gain any new sources, or change the order in which they were referenced
+    // (which would be caught above), we did *lose* some dependencies, and so we still need to
+    // remove ourselves from the sources we dropped and trim our sources list to match
+    unlinkObservers(node);
+    node._sources.length = idx;
   }
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -2,6 +2,10 @@ import type { Derived } from './derived.js';
 import type { Reaction } from './reaction.js';
 import type { Signal } from './signal.js';
 
+// Remove a given ReactiveFunction from all of its sources' observer arrays. In essence, this breaks
+// the link between a ReactiveFunction and all of its sources. We use this to "reset" a
+// ReactiveFunction's dependencies prior to re-computing it in order to ensure that we don't
+// leak dependencies between computations
 export function unlinkObservers(target: Derived<unknown> | Reaction) {
   const { _sources: sources } = target;
   if (!sources) {


### PR DESCRIPTION
Optimize dependency reconciliation using [this trick from Reactively](https://github.com/modderme123/reactively/commit/fde309bb2966e5d382868169f9b8905532596ec5) to allow for constant-time removal of observers and minimize the amount of reconciliation that needs to be done