### PR TITLE
docs: update Resource example with reactive source

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -291,8 +291,10 @@ The two-argument version of `createResource` allows you to designate a reactive 
 
 ```ts
 const pageNumber = createSignal(false);
-const postResource = createResource((pageNumber: number) =>
-  fetch(`api.com/posts/${pageNumber}`).then((res) => res.json())
+const postResource = createResource(
+  pageNumber,
+  (pageNumber: number) =>
+    fetch(`api.com/posts/${pageNumber}`).then((res) => res.json())
 );
 
 // No HTTP request has happened yet since `pageNumber` is false.


### PR DESCRIPTION
The example previously didn't include the reactive source argument, so it wasn't clear how it could react to the state change.