### PR TITLE
v0.1.0

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @signalis/core
 
+## 0.1.0
+
+### Minor Changes
+
+- move everything to 0.1.0
+
 ## 0.0.12
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalis/core",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "description": "",
   "type": "module",
   "files": [

--- a/packages/react-dummy-app/CHANGELOG.md
+++ b/packages/react-dummy-app/CHANGELOG.md
@@ -1,5 +1,12 @@
 # react-dummy-app
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies
+  - @signalis/react@0.1.0
+
 ## 0.0.6
 
 ### Patch Changes

--- a/packages/react-dummy-app/package.json
+++ b/packages/react-dummy-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-dummy-app",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @signalis/react
 
+## 0.1.0
+
+### Minor Changes
+
+- move everything to 0.1.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @signalis/core@0.1.0
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalis/react",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "",
   "type": "module",
   "files": [


### PR DESCRIPTION
Moving `@signalis/react` and `@signalis/core` to 0.1.0 to make hotfixes for consumers actually doable.